### PR TITLE
[Internal] Add Ruby support for logical types

### DIFF
--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -293,7 +293,7 @@ module Avro
 
         # function dispatch for reading data based on type of writer's
         # schema
-        case writers_schema.type_sym
+        datum = case writers_schema.type_sym
         when :null;    decoder.read_null
         when :boolean; decoder.read_boolean
         when :string;  decoder.read_string
@@ -311,6 +311,8 @@ module Avro
         else
           raise AvroError, "Cannot read unknown schema type: #{writers_schema.type}"
         end
+
+        readers_schema.logical_type.decode(datum)
       end
 
       def read_fixed(writers_schema, readers_schema, decoder)
@@ -538,7 +540,9 @@ module Avro
         write_data(writers_schema, datum, encoder)
       end
 
-      def write_data(writers_schema, datum, encoder)
+      def write_data(writers_schema, logical_datum, encoder)
+        datum = writers_schema.logical_type.encode(logical_datum)
+
         unless Schema.validate(writers_schema, datum)
           raise AvroTypeError.new(writers_schema, datum)
         end

--- a/lang/ruby/lib/avro/io.rb
+++ b/lang/ruby/lib/avro/io.rb
@@ -312,7 +312,7 @@ module Avro
           raise AvroError, "Cannot read unknown schema type: #{writers_schema.type}"
         end
 
-        readers_schema.logical_type.decode(datum)
+        readers_schema.type_adapter.decode(datum)
       end
 
       def read_fixed(writers_schema, readers_schema, decoder)
@@ -541,7 +541,7 @@ module Avro
       end
 
       def write_data(writers_schema, logical_datum, encoder)
-        datum = writers_schema.logical_type.encode(logical_datum)
+        datum = writers_schema.type_adapter.encode(logical_datum)
 
         unless Schema.validate(writers_schema, datum)
           raise AvroTypeError.new(writers_schema, datum)

--- a/lang/ruby/lib/avro/logical_types.rb
+++ b/lang/ruby/lib/avro/logical_types.rb
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'date'
+
+module Avro
+  module LogicalTypes
+    class IntDate
+      EPOCH_START = Date.new(1970, 1, 1)
+
+      def self.encode(date)
+        (date - EPOCH_START).to_i
+      end
+
+      def self.decode(int)
+        EPOCH_START + int
+      end
+    end
+
+    class TimestampMillis
+      def self.encode(value)
+        time = value.to_time
+        time.to_i * 1000 + time.usec / 1000
+      end
+
+      def self.decode(int)
+        s, ms = int / 1000, int % 1000
+        Time.at(s, ms * 1000)
+      end
+    end
+
+    class TimestampMicros
+      def self.encode(time)
+        time.to_i * 1000_000 + time.usec
+      end
+
+      def self.decode(int)
+        s, us = int / 1000_000, int % 1000_000
+        Time.at(s, us)
+      end
+    end
+
+    class Identity
+      def self.encode(datum)
+        datum
+      end
+
+      def self.decode(datum)
+        datum
+      end
+    end
+
+    TYPES = {
+      "int" => {
+        "date" => IntDate
+      },
+      "long" => {
+        "timestamp-millis" => TimestampMillis,
+        "timestamp-micros" => TimestampMicros
+      },
+    }
+
+    def self.parse(json_obj)
+      return unless json_obj['logicalType']
+
+      type_name = json_obj['type']
+      logical_type_name = json_obj['logicalType']
+
+      TYPES.fetch(type_name, {}).fetch(logical_type_name, Identity)
+    end
+  end
+end

--- a/lang/ruby/lib/avro/logical_types.rb
+++ b/lang/ruby/lib/avro/logical_types.rb
@@ -19,7 +19,7 @@ require 'date'
 
 module Avro
   module LogicalTypes
-    class IntDate
+    module IntDate
       EPOCH_START = Date.new(1970, 1, 1)
 
       def self.encode(date)
@@ -31,7 +31,7 @@ module Avro
       end
     end
 
-    class TimestampMillis
+    module TimestampMillis
       def self.encode(value)
         time = value.to_time
         time.to_i * 1000 + time.usec / 1000
@@ -39,22 +39,22 @@ module Avro
 
       def self.decode(int)
         s, ms = int / 1000, int % 1000
-        Time.at(s, ms * 1000)
+        Time.at(s, ms * 1000).utc
       end
     end
 
-    class TimestampMicros
+    module TimestampMicros
       def self.encode(time)
         time.to_i * 1000_000 + time.usec
       end
 
       def self.decode(int)
         s, us = int / 1000_000, int % 1000_000
-        Time.at(s, us)
+        Time.at(s, us).utc
       end
     end
 
-    class Identity
+    module Identity
       def self.encode(datum)
         datum
       end
@@ -72,15 +72,12 @@ module Avro
         "timestamp-millis" => TimestampMillis,
         "timestamp-micros" => TimestampMicros
       },
-    }
+    }.freeze
 
-    def self.parse(json_obj)
-      return unless json_obj['logicalType']
+    def self.type_adapter(type, logical_type)
+      return unless logical_type
 
-      type_name = json_obj['type']
-      logical_type_name = json_obj['logicalType']
-
-      TYPES.fetch(type_name, {}).fetch(logical_type_name, Identity)
+      TYPES.fetch(type, {}).fetch(logical_type, Identity)
     end
   end
 end

--- a/lang/ruby/lib/avro/schema.rb
+++ b/lang/ruby/lib/avro/schema.rb
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'avro/logical_types'
+
 module Avro
   class Schema
     # Sets of strings, for backwards compatibility. See below for sets of symbols,
@@ -33,7 +35,10 @@ module Avro
     LONG_MAX_VALUE = (1 << 63) - 1
 
     def self.parse(json_string)
-      real_parse(MultiJson.load(json_string), {})
+      json_obj = MultiJson.load(json_string)
+      schema = real_parse(json_obj, {})
+      schema.logical_type = LogicalTypes.parse(json_obj) if json_obj.is_a?(Hash)
+      schema
     end
 
     # Build Avro Schema from data parsed out of JSON string.
@@ -132,10 +137,15 @@ module Avro
     end
 
     attr_reader :type_sym
+    attr_writer :logical_type
 
     # Returns the type as a string (rather than a symbol), for backwards compatibility.
     # Deprecated in favor of {#type_sym}.
     def type; @type_sym.to_s; end
+
+    def logical_type
+      @logical_type || LogicalTypes::Identity
+    end
 
     # Returns the MD5 fingerprint of the schema as an Integer.
     def md5_fingerprint

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -23,6 +23,7 @@ class TestLogicalTypes < Test::Unit::TestCase
       { "type": "int", "logicalType": "date" }
     SCHEMA
 
+    assert_equal 'date', schema.logical_type
     assert_encode_and_decode Date.today, schema
   end
 
@@ -46,12 +47,17 @@ class TestLogicalTypes < Test::Unit::TestCase
     # The Time.at format is (seconds, microseconds) since Epoch.
     datum = Time.at(628232400, 12000)
 
+    assert_equal 'timestamp-millis', schema.logical_type
     assert_encode_and_decode datum, schema
   end
 
   def test_timestamp_millis_long_conversion
     type = Avro::LogicalTypes::TimestampMillis
 
+    now = Time.now.utc
+    now_millis = Time.utc(now.year, now.month, now.day, now.hour, now.min, now.sec, now.usec / 1000 * 1000)
+
+    assert_equal now_millis, type.decode(type.encode(now_millis))
     assert_equal 1432849613221, type.encode(Time.utc(2015, 5, 28, 21, 46, 53, 221000))
     assert_equal Time.utc(2015, 5, 28, 21, 46, 53, 221000), type.decode(1432849613221)
   end
@@ -64,7 +70,18 @@ class TestLogicalTypes < Test::Unit::TestCase
     # The Time.at format is (seconds, microseconds) since Epoch.
     datum = Time.at(628232400, 12345)
 
+    assert_equal 'timestamp-micros', schema.logical_type
     assert_encode_and_decode datum, schema
+  end
+
+  def test_timestamp_micros_long_conversion
+    type = Avro::LogicalTypes::TimestampMicros
+
+    now = Time.now.utc
+
+    assert_equal now, type.decode(type.encode(now))
+    assert_equal 1432849613221843, type.encode(Time.utc(2015, 5, 28, 21, 46, 53, 221843))
+    assert_equal Time.utc(2015, 5, 28, 21, 46, 53, 221843), type.decode(1432849613221843)
   end
 
   def encode(datum, schema)

--- a/lang/ruby/test/test_logical_types.rb
+++ b/lang/ruby/test/test_logical_types.rb
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'test_help'
+
+class TestLogicalTypes < Test::Unit::TestCase
+  def test_int_date
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "int", "logicalType": "date" }
+    SCHEMA
+
+    assert_encode_and_decode Date.today, schema
+  end
+
+  def test_int_date_conversion
+    type = Avro::LogicalTypes::IntDate
+
+    assert_equal 5, type.encode(Date.new(1970, 1, 6))
+    assert_equal 0, type.encode(Date.new(1970, 1, 1))
+    assert_equal -5, type.encode(Date.new(1969, 12, 27))
+
+    assert_equal Date.new(1970, 1, 6), type.decode(5)
+    assert_equal Date.new(1970, 1, 1), type.decode(0)
+    assert_equal Date.new(1969, 12, 27), type.decode(-5)
+  end
+
+  def test_timestamp_millis_long
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "long", "logicalType": "timestamp-millis" }
+    SCHEMA
+
+    # The Time.at format is (seconds, microseconds) since Epoch.
+    datum = Time.at(628232400, 12000)
+
+    assert_encode_and_decode datum, schema
+  end
+
+  def test_timestamp_millis_long_conversion
+    type = Avro::LogicalTypes::TimestampMillis
+
+    assert_equal 1432849613221, type.encode(Time.utc(2015, 5, 28, 21, 46, 53, 221000))
+    assert_equal Time.utc(2015, 5, 28, 21, 46, 53, 221000), type.decode(1432849613221)
+  end
+
+  def test_timestamp_micros_long
+    schema = Avro::Schema.parse <<-SCHEMA
+      { "type": "long", "logicalType": "timestamp-micros" }
+    SCHEMA
+
+    # The Time.at format is (seconds, microseconds) since Epoch.
+    datum = Time.at(628232400, 12345)
+
+    assert_encode_and_decode datum, schema
+  end
+
+  def encode(datum, schema)
+    buffer = StringIO.new("")
+    encoder = Avro::IO::BinaryEncoder.new(buffer)
+
+    datum_writer = Avro::IO::DatumWriter.new(schema)
+    datum_writer.write(datum, encoder)
+
+    buffer.string
+  end
+
+  def decode(encoded, schema)
+    buffer = StringIO.new(encoded)
+    decoder = Avro::IO::BinaryDecoder.new(buffer)
+
+    datum_reader = Avro::IO::DatumReader.new(schema, schema)
+    datum_reader.read(decoder)
+  end
+
+  def assert_encode_and_decode(datum, schema)
+    encoded = encode(datum, schema)
+    assert_equal datum, decode(encoded, schema)
+  end
+end


### PR DESCRIPTION
The first commit preserves the original work on logical types by dasch.

The second commit is mostly intended to address the outstanding feedback on https://github.com/apache/avro/pull/44:

    * Move logical_type determination into `.real_parse`.
    * `#logical_type` now returns the logical type name.
    * Change logical type "adapters" to modules since there will be no instances.
    * Parity with Java conversion tests.

The main change that I've made from the original work is to expose the name of the logical type as a `#logical_type` method. Previously, it returned the "type" used for encoding and decoding. I've renamed that to `logical_type_adapter` and changed those classes to modules.